### PR TITLE
fix: Fix Child routes loading all direct parents components

### DIFF
--- a/Web/Server/Server.tsx
+++ b/Web/Server/Server.tsx
@@ -114,7 +114,10 @@ export async function uiServer(
   const appStream = renderToNodeStream(sheets.collect(AppComponent));
 
   headStream.on('end', async () => {
-    await renderToStringWithData(AppComponent);
+    try {
+      await renderToStringWithData(AppComponent);
+    } catch {}
+
     renderToString(sheets.collect(AppComponent));
     ctx.res.write(`<style id="jss-server-side">${sheets.toString()}</style>`);
     ctx.res.write('</head><body><div id="app">');

--- a/Web/UI/Components/Providers/ApolloProvider.tsx
+++ b/Web/UI/Components/Providers/ApolloProvider.tsx
@@ -27,9 +27,10 @@ export function ApolloProvider({
     token,
     initialState:
       typeof window !== 'undefined' ? window.APP_STATE.APOLLO_STATE : {},
-    onError: ({ graphQLErrors }) => {
-      if (graphQLErrors?.some(({ message }) => message === 'Argument Validation Error')) return
-      enqueueSnackbar('GraphQL Error', { variant: 'error' });
+    onError: ({ networkError, operation: { getContext } }) => {
+      if (getContext().ignoreError === true) return
+      if (networkError?.name === 'ServerParseError')  enqueueSnackbar('API Connection Failed', { variant: 'error', persist: true  })
+      else enqueueSnackbar('GraphQL Error', { variant: 'error' });
     },
   });
 

--- a/Web/UI/Components/Providers/Session/useLogin.ts
+++ b/Web/UI/Components/Providers/Session/useLogin.ts
@@ -8,7 +8,9 @@ type LoginFunction = (input: LoginInput) => Promise<boolean>;
 
 export function useLogin(): [LoginFunction, LoginMutationResult] {
   const { setToken } = useToken();
-  const [loginFn, extras] = useLoginMutation();
+  const [loginFn, extras] = useLoginMutation({
+    context: { ignoreError: true },
+  });
   const login: LoginFunction = useCallback(
     async (input) => {
       const response = await loginFn({ variables: { input } });

--- a/Web/UI/Components/Router/Route.tsx
+++ b/Web/UI/Components/Router/Route.tsx
@@ -10,9 +10,23 @@ export interface ImportedRouteInput {
 }
 
 interface RouteProps {
-  imported: ImportedRouteInput;
+  imported?: ImportedRouteInput;
   path: string;
   exact?: boolean;
+}
+
+function Loadable({
+  imported,
+}: {
+  imported?: ImportedRouteInput;
+}): React.ReactElement {
+  const Component = useImport({
+    imported: imported?.imported || import('UI/Routes/Error'),
+    path: imported?.path || 'Routes/Error/index.tsx',
+    Loader,
+  });
+
+  return <Component />;
 }
 
 export function Route({
@@ -21,29 +35,20 @@ export function Route({
   path,
   exact = false,
 }: PropsWithChildren<RouteProps>): React.ReactElement {
-  const Component = useImport({
-    ...imported,
-    Loader,
-  });
-
   if (children)
     return (
-      <RouteComponent
-        path={path}
-        render={() => (
-          <>
-            {' '}
-            <RouteComponent
-              key={path}
-              path={`${path}/`}
-              exact
-              component={Component}
-            />
-            {children}
-          </>
-        )}
-      />
+      <RouteComponent path={path}>
+        <RouteComponent path={`${path}/`} exact>
+          <Loadable imported={imported} />
+        </RouteComponent>
+
+        {children}
+      </RouteComponent>
     );
 
-  return <RouteComponent exact={exact} path={path} component={Component} />;
+  return (
+    <RouteComponent exact={exact} path={path}>
+      <Loadable imported={imported} />
+    </RouteComponent>
+  );
 }


### PR DESCRIPTION
This fixes the fact that a child route loaded all the useImports from all parent routes